### PR TITLE
SSEを利用して在室者一覧を自動更新するようにした

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -33,6 +33,9 @@ export default {
     ...mapGetters({
       room_user: 'logging/inRoomUsers'
     })
+  },
+  created () {
+    this.$store.dispatch('logging/setUpSSE')
   }
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,6 +24,7 @@ export default {
   },
   fetch ({ store }) {
     store.dispatch('logging/getInRoomUsers')
+    store.dispatch('logging/setUpSSE')
   },
   head: {
     title: 'ITS-AMS コントロールパネル',
@@ -33,9 +34,6 @@ export default {
     ...mapGetters({
       room_user: 'logging/inRoomUsers'
     })
-  },
-  created () {
-    this.$store.dispatch('logging/setUpSSE')
   }
 }
 </script>

--- a/store/logging.js
+++ b/store/logging.js
@@ -94,8 +94,8 @@ export const actions = {
    * @param state
    */
   setUpSSE ({ commit }) {
-    // TODO: baseUrlをnuxt.config.jsから持ってきたい
-    const evtSrc = new EventSource('http://localhost:3000/v1/users_updated_event')
+    const baseUrl = process.env.baseUrl
+    const evtSrc = new EventSource(baseUrl + '/users_updated_event')
 
     evtSrc.addEventListener('usersUpdated', (e) => {
       try {

--- a/store/logging.js
+++ b/store/logging.js
@@ -88,5 +88,22 @@ export const actions = {
       commit('SET_ACCESS_LOGS', Response.data.data)
       commit('SET_ACCESS_LOG_METADATA', Response.data.meta)
     })
+  },
+  /**
+   * バックエンドからのイベント通知に対するリスナーを設定する
+   * @param state
+   */
+  setUpSSE ({ commit }) {
+    // TODO: baseUrlをnuxt.config.jsから持ってきたい
+    const evtSrc = new EventSource('http://localhost:3000/v1/users_updated_event')
+
+    evtSrc.addEventListener('usersUpdated', (e) => {
+      try {
+        const json = JSON.parse(e.data)
+        commit('SET_IN_ROOM_USERS', json.data)
+      } catch (error) {
+        // console.log('error in parse mesg:', error)
+      }
+    })
   }
 }

--- a/store/logging.js
+++ b/store/logging.js
@@ -97,13 +97,25 @@ export const actions = {
     const baseUrl = process.env.baseUrl
     const evtSrc = new EventSource(baseUrl + '/users_updated_event')
 
+    /* eslint-disable no-console */
+
+    // 在室者一覧が更新されたときにバックエンドから来るイベント
     evtSrc.addEventListener('usersUpdated', (e) => {
       try {
         const json = JSON.parse(e.data)
         commit('SET_IN_ROOM_USERS', json.data)
       } catch (error) {
-        // console.log('error in parse mesg:', error)
+        // commitは失敗しないので、JSONのパース失敗を考える
+        // 失敗するようなJSONを送ってくるバックエンドが悪いので
+        // debugで出しておく
+        console.debug('SSE: JSONパース失敗', error)
       }
+    })
+
+    // SSE で何らかのエラーが起きたときのイベント
+    evtSrc.addEventListener('error', (_) => {
+      // 自動で再接続されるのでdebugだけ出しておく
+      console.debug('SSE: エラーのため再接続')
     })
   }
 }


### PR DESCRIPTION
とりあえず普通のJSで書く時と同じ方法でSSEのハンドリングを実装して、loggingストアのactionsに `setUpSSE` として放り込みました。
最初に `setUpSSE` を呼んでやるとイベントハンドラにストアの処理を入れてくれて、あとは裏で勝手に更新してくれます。

※イベントのデータ構造を https://github.com/su-its/ams-backend-nodejs/pull/54 に合わせてあるので、テスト時はバックエンドをそっちからチェックアウトしてください。

TODO:
- この書き方でいいのか（Nuxtにもっといい書き方がないか）
- ~ストアで `baseUrl` を取ってくる方法が知りたい (axiosが使えないので別途必要になる)~

---

closes #24