### PR TITLE
Nuxtのテレメトリを無効化

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -65,5 +65,6 @@ export default {
   },
   // ビルドの設定
   build: {
-  }
+  },
+  telemetry: false
 }


### PR DESCRIPTION
インタラクティブでない環境でテレメトリ関連の質問が
出ると困るかもしれないのであらかじめ無効にしておく