### PR TITLE
在室状況画面を調整

### DIFF
--- a/components/InRoomUsers.vue
+++ b/components/InRoomUsers.vue
@@ -1,20 +1,20 @@
 <template>
-  <div class="section">
-    <div class="card">
-      <div class="card-header">
-        <p class="card-header-title">
-          静岡大学 ITソルーション室
-        </p>
-      </div>
-      <div class="card-content">
-        <div v-if="roomUser.length != 0" id="user-count" class="content">
-          現在、 {{ roomUser.length }} 人 が在室中です。
-          <div v-for="user in roomUser" :key="user.id" class="has-shadow">
-            <User :user="user" />
-          </div>
-        </div>
-        <div v-else class="has-shadow">
-          現在、不在です。
+  <div class="card">
+    <div class="card-header">
+      <p class="card-header-title">
+        在室状況
+      </p>
+    </div>
+    <div class="card-content">
+      <p v-if="roomUser.length == 0" class="content">
+        現在、誰も在室していません。
+      </p>
+      <p v-else class="content">
+        現在、 {{ roomUser.length }} 人 が在室中です。
+      </p>
+      <div class="content">
+        <div v-for="user in roomUser" :key="user.id">
+          <User :user="user" />
         </div>
       </div>
     </div>

--- a/components/UserInfo.vue
+++ b/components/UserInfo.vue
@@ -1,21 +1,19 @@
 <template>
-  <div class="content">
-    <div class="card">
-      <div class="card-content">
-        <div class="media">
-          <div class="media-left">
-            <figure class="image is-48x48">
-              <img src="https://bulma.io/images/placeholders/96x96.png">
-            </figure>
-          </div>
-          <div class="media-content">
-            <p class="title is-4">
-              {{ user.user_id }}
-            </p>
-            <p class="subtitle is-6">
-              {{ user.user_id }}
-            </p>
-          </div>
+  <div class="card">
+    <div class="card-content">
+      <div class="media">
+        <div class="media-left">
+          <figure class="image is-48x48">
+            <img src="https://bulma.io/images/placeholders/96x96.png">
+          </figure>
+        </div>
+        <div class="media-content">
+          <p class="title is-4">
+            {{ user.user_id }}
+          </p>
+          <p class="subtitle is-6">
+            {{ user.user_id }}
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- 「静岡大学 ITソルーション室」の表記を「在室状況」に置換
- 他画面に比べて表示領域が小さかったのを修正(モックアップと構造を合わせた)

Before:
![Screenshot_2021-03-27 ITS-AMS コントロールパネル](https://user-images.githubusercontent.com/8597717/112717158-2069bc00-8f2e-11eb-952b-65129d38d50b.png)

After:
![Screenshot_2021-03-27 ITS-AMS コントロールパネル(1)](https://user-images.githubusercontent.com/8597717/112717170-35464f80-8f2e-11eb-961f-506809a2cb29.png)
