### PR TITLE
ビルド時の設定を変更

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -78,6 +78,9 @@ export default {
 
   // ビルドの設定
   build: {
+    cache: true,
+    hardSource: true,
+    parallel: true
   },
 
   telemetry: false,


### PR DESCRIPTION
(以下は調べただけなので正しいかは微妙)
cache: ビルド結果のキャッシュをする
hardSource: 改変されたソースだけをビルドする
parallel: Webpackでスレッドプールを使う

手元のラズパイではビルド時間が2分→1分未満になった