### PR TITLE
package.jsonからフロントエンドのバージョンを取得して画面に表示する

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,5 @@
+import * as packageJson from './package.json'
+
 export default {
   server: {
     // ポート番号を指定
@@ -7,6 +9,11 @@ export default {
   axios: {
     proxy: true,
     prefix: '/api'
+  },
+
+  env: {
+    // このソフトのバージョンを設定(画面に表示するため)
+    PKG_VERSION: packageJson.version || '0.1.0'
   },
 
   proxy: {
@@ -89,5 +96,4 @@ export default {
     // SSEと圧縮の相性が悪いのでオフにしておく
     compressor: false
   }
-
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -86,7 +86,6 @@ export default {
   // ビルドの設定
   build: {
     cache: true,
-    hardSource: true,
     parallel: true
   },
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -13,7 +13,7 @@ export default {
 
   env: {
     // このソフトのバージョンを設定(画面に表示するため)
-    PKG_VERSION: packageJson.version || '0.1.0'
+    PKG_VERSION: packageJson.version || 'バージョン情報の取得に失敗しました'
   },
 
   proxy: {

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -15,7 +15,7 @@
           <div class="card-content">
             <div class="content">
               <p>
-                Ver.0.1.0<br>
+                Ver.{{ PKG_VERSION }}<br>
                 (c) 2021 IT Solution Room, Shizuoka University
               </p>
             </div>
@@ -58,7 +58,8 @@ export default {
   },
   computed: {
     ...mapGetters({
-      API_Version: 'version/apiVersion'
+      API_Version: 'version/apiVersion',
+      PKG_VERSION: 'version/pkgVersion'
     })
   }
 }

--- a/store/version.js
+++ b/store/version.js
@@ -1,5 +1,6 @@
 export const state = () => ({
-  api_version: {}
+  api_version: {},
+  pkg_version: process.env.PKG_VERSION || '0.1.0'
 })
 
 export const mutations = {
@@ -24,6 +25,14 @@ export const getters = {
    */
   apiVersion: (state) => {
     return state.api_version
+  },
+  /**
+   * package.jsonに書いてあるversionのゲッタ
+   * @param {*} state
+   * @returns {string}
+   */
+  pkgVersion: (state) => {
+    return state.pkg_version
   }
 }
 

--- a/store/version.js
+++ b/store/version.js
@@ -1,6 +1,6 @@
 export const state = () => ({
   api_version: {},
-  pkg_version: process.env.PKG_VERSION || '0.1.0'
+  pkg_version: process.env.PKG_VERSION
 })
 
 export const mutations = {


### PR DESCRIPTION
(この他の場合若干挙動が怪しいのですが少なくとも)`.nuxt/`がまっさらな状態で`npm run dev`なり`npm run build`してできたものについてはpackage.jsonの`version`をしっかり取得できるようになったのでこれでレビューお願いします．

[参考1: package.jsonからバージョンを取得する方法について](https://medium.com/hceverything/how-to-show-your-app-version-from-package-json-in-your-vue-application-11e882b97d8c)
[参考2: NuxtJS ストアについて](https://ja.nuxtjs.org/docs/2.x/directory-structure/store/)
[参考3: Vuex ゲッターについて](https://vuex.vuejs.org/ja/guide/getters.html)

---

close #30 