### PR TITLE
プロクシが x-forwarded-for ヘッダを付けるようにした

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -23,7 +23,8 @@ export default {
       pathRewrite: {
         // 余計なパスを取り除く
         '^/api': '/'
-      }
+      },
+      xfwd: true // x-forwarded-for を付ける
     }
   },
 


### PR DESCRIPTION
プロクシ経由でアクセスされるとバックエンドからはリモートアドレスが見えないので、このヘッダを使って元のリモートアドレスを通知する。