### PR TITLE
proxyの書き方をnuxt/axiosのexampleの通りにした

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -18,11 +18,11 @@ export default {
 
   proxy: {
     // バックエンドAPIをプロクシする
-    '/api': {
+    '/api/': {
       target: process.env.API_URL,
       pathRewrite: {
         // 余計なパスを取り除く
-        '^/api': '/'
+        '^/api/': ''
       },
       xfwd: true // x-forwarded-for を付ける
     }


### PR DESCRIPTION
# proxyの書き方をnuxt/axiosのexampleの通りにした

バックエンドで記録されるログファイルを眺めているときに以下の`/v1/`のような「trailing slash」が気持ち悪いなと思ったのでそうならないようにしました．既存のフロントエンドからのリクエストは全て問題なく捌けていたので大丈夫だと思います．

```plain
::ffff:127.0.0.1 - - [2021-03-29T20:24:54+09:00] "GET /v1/ HTTP/1.1" 304 - "http://localhost:3001/log" "Mozilla …
```

- `get('')`をやめさせられる→分かりやすい(/へのリクエストでも`get('')`ではなく必ず`get('/')`と書かないといけない)
- クエリパラメータが無い時はtrailing slashがつかなくなる